### PR TITLE
Spawn player at map centre

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -146,7 +146,7 @@ func handleConnectRequest(message *resources.Message, conn *websocket.Conn) (uin
 		username: username,
 		password: password,
 		conn:     conn,
-		collider: resolv.NewCircle(9, 9, 8),
+		collider: resolv.NewCircle(400, 400, 8),
 	}
 
 	ServerInstance.Space.Add(newClient.collider)
@@ -158,8 +158,8 @@ func handleConnectRequest(message *resources.Message, conn *websocket.Conn) (uin
 	// Send reponse to client
 	conn.WriteJSON(resources.NewConnectResponseMessage(resources.ConnectResponseContents{
 		ClientId: newClient.id,
-		Pos:      f64.Vec2{1, 1},
-		Tile:     f64.Vec2{0, 0},
+		Pos:      f64.Vec2{400, 400},
+		Tile:     f64.Vec2{50, 50},
 		WorldMap: ServerInstance.worldMap,
 	}))
 
@@ -178,8 +178,8 @@ func handleConnectRequest(message *resources.Message, conn *websocket.Conn) (uin
 
 	// Update all other clients
 	sendUpdateToClients(resources.NewUpdateMessage(newClient.id, resources.UpdateContents{
-		Pos:      f64.Vec2{1, 1},
-		Tile:     f64.Vec2{0, 0},
+		Pos:      f64.Vec2{400, 400},
+		Tile:     f64.Vec2{50, 50},
 		Username: newClient.username,
 	}))
 

--- a/server/worldgen.go
+++ b/server/worldgen.go
@@ -37,7 +37,7 @@ func GenerateWorldMap() resources.WorldMap {
 		ty := sandEdge + rand.Intn(mapHeight-sandEdge*2)
 
 		// Keep a small clear zone around the spawn point
-		if tx < 5 && ty < 5 {
+		if tx >= 47 && tx <= 53 && ty >= 47 && ty <= 53 {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- New players now spawn at tile (50, 50) / pixel (400, 400) — the centre of the 100×100 map — instead of the top-left corner (1, 1)
- Collider initial position updated to match
- Tree clear zone in world generation moved from top-left to the centre tiles (47–53, 47–53) so the spawn area is open ground

## Test plan

- [ ] Connect as a new player and confirm you start in the middle of the map
- [ ] Confirm the area around the spawn is free of trees
- [ ] Confirm reconnecting as an existing player still restores the saved position