### PR TITLE
Sprite flipping and NPC tree collision

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -194,7 +194,7 @@ func receiveUpdateMessage(message *resources.Message, g *Game) {
 	networkClient, found := client.NetworkPlayers[message.ClientId]
 
 	if found {
-		networkClient.Position = f64.Vec2{pos[0].(float64), pos[1].(float64)}
+		networkClient.SetPosition(f64.Vec2{pos[0].(float64), pos[1].(float64)})
 		networkClient.Tile = f64.Vec2{tile[0].(float64), tile[1].(float64)}
 		return
 	}
@@ -221,7 +221,7 @@ func receiveEntityUpdateMessage(message *resources.Message, g *Game) {
 		np, found := client.NetworkPlayers[uint16(entityId)]
 
 		if found {
-			np.Position = f64.Vec2{pos[0].(float64), pos[1].(float64)}
+			np.SetPosition(f64.Vec2{pos[0].(float64), pos[1].(float64)})
 			np.Tile = f64.Vec2{tile[0].(float64), tile[1].(float64)}
 			continue
 		}

--- a/client/entities/network_player.go
+++ b/client/entities/network_player.go
@@ -17,6 +17,16 @@ type NetworkPlayer struct {
 	Position  f64.Vec2
 	Tile      f64.Vec2
 	Cam       *camera.Camera
+	flipX     bool
+}
+
+func (p *NetworkPlayer) SetPosition(pos f64.Vec2) {
+	if pos[0] < p.Position[0] {
+		p.flipX = true
+	} else if pos[0] > p.Position[0] {
+		p.flipX = false
+	}
+	p.Position = pos
 }
 
 func NewNetworkPlayer(tilesImage *ebiten.Image, tile f64.Vec2) *NetworkPlayer {
@@ -45,7 +55,12 @@ func (p *NetworkPlayer) Draw(screen *ebiten.Image) {
 	// text.Draw(screen, p.Username, mplusNormalFont, int(p.Position[0]*settings.Scale), int(p.Position[1]*settings.Scale), color.White)
 
 	// Draw the player
-	opts := p.Cam.GetTranslation(&ebiten.DrawImageOptions{}, p.Position[0], p.Position[1])
+	drawOpts := &ebiten.DrawImageOptions{}
+	if p.flipX {
+		drawOpts.GeoM.Scale(-1, 1)
+		drawOpts.GeoM.Translate(8, 0)
+	}
+	opts := p.Cam.GetTranslation(drawOpts, p.Position[0], p.Position[1])
 	p.Cam.Surface.DrawImage(p.imageTile, opts)
 
 	// Draw username above the sprite using the same screen-space position

--- a/client/entities/player.go
+++ b/client/entities/player.go
@@ -27,6 +27,7 @@ type Player struct {
 	SendChan  chan resources.UpdateContents
 	Cam       *camera.Camera
 	WorldMap  *resources.WorldMap
+	flipX     bool
 }
 
 func init() {
@@ -61,9 +62,11 @@ func (p *Player) Update() error {
 
 	if ebiten.IsKeyPressed(ebiten.KeyA) || ebiten.IsKeyPressed(ebiten.KeyArrowLeft) {
 		x -= 1
+		p.flipX = true
 	}
 	if ebiten.IsKeyPressed(ebiten.KeyD) || ebiten.IsKeyPressed(ebiten.KeyArrowRight) {
 		x += 1
+		p.flipX = false
 	}
 	if ebiten.IsKeyPressed(ebiten.KeyW) || ebiten.IsKeyPressed(ebiten.KeyArrowUp) {
 		y -= 1
@@ -138,7 +141,12 @@ func (p *Player) Draw(screen *ebiten.Image) {
 	// text.Draw(screen, p.Username, mplusNormalFont, int(p.Position[0]), int(p.Position[1]), color.White)
 
 	// Draw the player
-	opts := p.Cam.GetTranslation(&ebiten.DrawImageOptions{}, p.Position[0], p.Position[1])
+	drawOpts := &ebiten.DrawImageOptions{}
+	if p.flipX {
+		drawOpts.GeoM.Scale(-1, 1)
+		drawOpts.GeoM.Translate(8, 0)
+	}
+	opts := p.Cam.GetTranslation(drawOpts, p.Position[0], p.Position[1])
 	p.Cam.Surface.DrawImage(p.imageTile, opts)
 
 	// Draw username above the sprite using the same screen-space position

--- a/server/npc.go
+++ b/server/npc.go
@@ -48,6 +48,25 @@ func randomMapPos() f64.Vec2 {
 	}
 }
 
+func npcCanMoveTo(px, py float64) bool {
+	wm := ServerInstance.worldMap
+	if len(wm.Layers) == 0 {
+		return true
+	}
+	w := wm.Width
+	data := wm.Layers[0].Data
+	for _, corner := range [4][2]float64{{px, py}, {px + 7, py}, {px, py + 7}, {px + 7, py + 7}} {
+		tx, ty := int(corner[0]/8), int(corner[1]/8)
+		if tx < 0 || ty < 0 || tx >= w || ty >= wm.Height {
+			return false
+		}
+		if !resources.IsPassable(data[ty*w+tx]) {
+			return false
+		}
+	}
+	return true
+}
+
 func npcLoop(npcs []*NPC) {
 	for {
 		time.Sleep(25 * time.Millisecond)
@@ -59,8 +78,15 @@ func npcLoop(npcs []*NPC) {
 			dist := math.Sqrt(dx*dx + dy*dy)
 			if dist > 1 {
 				const speed = 0.3
-				npc.position[0] += (dx / dist) * speed
-				npc.position[1] += (dy / dist) * speed
+				newX := npc.position[0] + (dx/dist)*speed
+				newY := npc.position[1] + (dy/dist)*speed
+				if npcCanMoveTo(newX, newY) {
+					npc.position[0] = newX
+					npc.position[1] = newY
+				} else {
+					npc.target = randomMapPos()
+					npc.ticksToNewTarget = 300 + rand.Intn(300)
+				}
 			}
 
 			npc.ticksToNewTarget--


### PR DESCRIPTION
## Summary

- **Sprite flipping (client):** Pressing A/left flips the player sprite horizontally; D/right flips it back. W/S have no effect on facing direction.
- **Network player & NPC flipping (client):** `NetworkPlayer` gains a `SetPosition()` method that derives facing direction from X movement delta and applies the same horizontal flip — covers both remote players and NPCs as received from the server.
- **NPC tree collision (server):** Added `npcCanMoveTo()` which checks all four corners of the 8×8 NPC sprite against world map tile data. NPCs now pick a new random target instead of walking through trees or water.

## Test plan

- [ ] Local player sprite flips when moving left, resets when moving right
- [ ] W/S keys do not affect sprite facing
- [ ] Remote players visible to other clients flip correctly based on their movement
- [ ] NPCs (Bob, Alice, Charlie) no longer walk through trees or water
- [ ] NPCs continue to roam and chat normally